### PR TITLE
Managed TypeConversion.ImplicitConversion on GetBinaryOperator 

### DIFF
--- a/ExpressionEvaluator/Parser/ExpressionHelper.cs
+++ b/ExpressionEvaluator/Parser/ExpressionHelper.cs
@@ -1061,11 +1061,8 @@ namespace ExpressionEvaluator.Parser
                 re = TypeConversion.EnumConversion(ref re);
                 le = TypeConversion.EnumConversion(ref le);
 
-                var ret = re.Type;
-                var let = le.Type;
-
-                TypeConversion.ImplicitConversion(ref le, ret);
-                TypeConversion.ImplicitConversion(ref re, let);
+                
+                TypeConversion.ImplicitConversion(ref le, ref re);
                 //TypeConversion.BinaryNumericPromotion(expressionType, ref le, ref re);
                 //le = TypeConversion.DynamicConversion(re, le);
                 return GetBinaryOperator(le, re, expressionType);

--- a/ExpressionEvaluator/Parser/TypeExtensions.cs
+++ b/ExpressionEvaluator/Parser/TypeExtensions.cs
@@ -28,6 +28,11 @@ namespace ExpressionEvaluator.Parser
             return NumericTypes.Contains(type);
         }
 
+        public static Type GetNotNullable(this Type type)
+        {
+            return Nullable.GetUnderlyingType(type) ?? type;
+        }
+
         public static bool IsDynamicOrObject(this Type type)
         {
             return type.GetInterfaces().Contains(typeof(IDynamicMetaObjectProvider)) ||


### PR DESCRIPTION
Managed TypeConversion.ImplicitConversion on GetBinaryOperator to detect the common type of two expressions.
Now can use a expression P1 / P2 where P1 : double and P2: nullable of decimal or other type

My Error is:
L'operatore binario Divide non è definito per i tipi 'System.Nullable`1[System.Decimal]' e 'System.Double'.
   in System.Linq.Expressions.Expression.GetUserDefinedBinaryOperatorOrThrow(ExpressionType binaryType, String name, Expression left, Expression right, Boolean liftToNull)
   in System.Linq.Expressions.Expression.Divide(Expression left, Expression right, MethodInfo method)
   in ExpressionEvaluator.Parser.ExpressionHelper.GetBinaryOperator(Expression le, Expression re, ExpressionType expressionType)
   in ExpressionEvaluator.Parser.ExpressionHelper.BinaryOperator(Expression le, Expression re, ExpressionType expressionType)
   in ExpressionEvaluator.Parser.ExprEvalParser.multiplicative_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.additive_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.shift_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.relational_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.equality_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.and_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.exclusive_or_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.inclusive_or_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.conditional_and_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.conditional_or_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.null_coalescing_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.conditional_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.non_assignment_expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.expression()
   in ExpressionEvaluator.Parser.ExprEvalParser.single_expression()
   in ExpressionEvaluator.Parser.AntlrParser.Parse(Expression scope, Boolean isCall)
   in ExpressionEvaluator.ExpressionCompiler.BuildTree(Expression scopeParam, Boolean isCall)
   in ExpressionEvaluator.CompiledExpression`1.CompileWithScope[T,TScope](Boolean asCall)
   in ExpressionEvaluator.CompiledExpression`1.ScopeCompile[TScope]()
   in ConsoleApplication1.Program.Main(String[] args) in C:\Users\Davide\documents\visual studio 2015\Projects\ConsoleApplication1\ConsoleApplication1\Program.cs:riga 25
   in System.AppDomain._nExecuteAssembly(RuntimeAssembly assembly, String[] args)
   in System.AppDomain.ExecuteAssembly(String assemblyFile, Evidence assemblySecurity, String[] args)
   in Microsoft.VisualStudio.HostingProcess.HostProc.RunUsersAssembly()
   in System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   in System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   in System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   in System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   in System.Threading.ThreadHelper.ThreadStart()